### PR TITLE
Make ROS1 optional for extract_rosbag_data.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ CATKIN_IGNORE
 build
 install
 log
+
+# Python virtual environment
+venv/

--- a/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
+++ b/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
@@ -39,23 +39,8 @@ import os
 from pathlib import Path
 from typing import List, Dict
 import sys
+from abc import ABC, abstractmethod
 
-try:
-    import rosbag
-    from cv_bridge import CvBridge
-    cv_bridge = CvBridge()
-    from rospy import Time
-except ModuleNotFoundError:
-    rosbag = None
-    cv_bridge = None
-
-    from rosbags.rosbag1 import Reader
-    from rosbags.image import message_to_cvimage
-    from rosbags.typesys import Stores, get_typestore
-
-    typestore = get_typestore(Stores.ROS1_NOETIC)
-
-    from typing import override
 
 SCRIPT_DESCRIPTION = \
     "This script allows the extraction of the rosbag data format to plain" \
@@ -98,83 +83,107 @@ OUTPUT_STRUCTURE = \
     │   └── 2023-12-26-15-48-38/
     """
 
-class Bag:
+class Bag(ABC):
     def __init__(self, path: Path):
-        super().__init__()
+        pass
 
+    @abstractmethod
     def get_start_time(self):
         raise NotImplementedError()
 
+    @abstractmethod
     def get_end_time(self):
         raise NotImplementedError()
 
+    @abstractmethod
     def read_messages(self, topics, start, stop):
         raise NotImplementedError()
 
+    @abstractmethod
     def get_topics(self):
         raise NotImplementedError()
 
-if rosbag:
-    class BagROS1(Bag):
-        bag: rosbag.Bag
 
-        def __init__(self, path: Path):
-            self.bag = rosbag.Bag(path)
+def get_bag_handler(path: Path):
+    try:
+        import rosbag
+        from rospy import Time
 
-        def get_start_time(self):
-            return self.floatsec_to_intnsec(self.bag.get_start_time())
+        class NativeBag(Bag):
+            bag: rosbag.Bag
 
-        def get_end_time(self):
-            return self.floatsec_to_intnsec(self.bag.get_end_time())
+            def __init__(self, path: Path):
+                super().__init__(path)
+                self.bag = rosbag.Bag(path)
 
-        def read_messages(self, topics, start, stop):
-            for topic, msg, t in self.bag.read_messages(
-                        topics,
-                        start_time=Time(self.intnsec_to_floatsec(start)),
-                        end_time=Time(self.intnsec_to_floatsec(stop))
-                    ):
-                yield (topic, msg, t.secs * int(1e9) + t.nsecs)
+            def get_start_time(self):
+                return self.floatsec_to_intnsec(self.bag.get_start_time())
 
-        def get_topics(self):
-            return self.bag.get_type_and_topic_info().topics
+            def get_end_time(self):
+                return self.floatsec_to_intnsec(self.bag.get_end_time())
 
-        @staticmethod
-        def floatsec_to_intnsec(float_sec):
-            int_sec = int(float_sec)
-            rem_sec = float_sec - int_sec
-            rem_nsec = int(rem_sec * int(1e9))
-            return (int_sec * int(1e9)) + rem_nsec
+            def read_messages(self, topics, start, stop):
+                for topic, msg, t in self.bag.read_messages(
+                            topics,
+                            start_time=Time(self.intnsec_to_floatsec(start)),
+                            end_time=Time(self.intnsec_to_floatsec(stop))
+                        ):
+                    yield (topic, msg, t.to_nsec())
 
-        @staticmethod
-        def intnsec_to_floatsec(intnsec):
-            return (float(intnsec) / 1e9)
-else:
-    class BagRosbags(Bag):
-        bag: Reader
+            def get_topics(self):
+                return self.bag.get_type_and_topic_info().topics
 
-        def __init__(self, path: Path):
-            self.bag = Reader(path)
-            self.bag.open()
+            @staticmethod
+            def floatsec_to_intnsec(float_sec):
+                int_sec = int(float_sec)
+                rem_sec = float_sec - int_sec
+                rem_nsec = int(rem_sec * int(1e9))
+                return (int_sec * int(1e9)) + rem_nsec
 
-        @override
-        def get_start_time(self):
-            return self.bag.start_time
+            @staticmethod
+            def intnsec_to_floatsec(intnsec):
+                return (float(intnsec) / 1e9)
 
-        @override
-        def get_end_time(self):
-            return self.bag.end_time
+        return NativeBag(path)
+    except ImportError:
+        from rosbags.rosbag1 import Reader
+        from rosbags.typesys import Stores, get_typestore
 
-        @override
-        def read_messages(self, topics, start, stop):
-            connections = [x for x in self.bag.connections if x.topic in topics]
-            for connection, timestamp, rawdata in self.bag.messages(connections=connections, start=start, stop=stop):
-                msg = typestore.deserialize_ros1(rawdata, connection.msgtype)
-                yield connection.topic, msg, timestamp
+        typestore = get_typestore(Stores.ROS1_NOETIC)
 
-        @override
-        def get_topics(self):
-            return self.bag.topics
+        class RosbagsBag(Bag):
+            bag: Reader
 
+            def __init__(self, path: Path):
+                self.bag = Reader(path)
+                self.bag.open()
+
+            def get_start_time(self):
+                return self.bag.start_time
+
+            def get_end_time(self):
+                return self.bag.end_time
+
+            def read_messages(self, topics, start, stop):
+                connections = [x for x in self.bag.connections if x.topic in topics]
+                for connection, timestamp, rawdata in self.bag.messages(connections=connections, start=start, stop=stop):
+                    msg = typestore.deserialize_ros1(rawdata, connection.msgtype)
+                    yield connection.topic, msg, timestamp
+
+            def get_topics(self):
+                return self.bag.topics
+
+        return RosbagsBag(path)
+
+def to_nsec(timestamp):
+    sec = getattr(timestamp, 'sec', None)
+    nsec = getattr(timestamp, 'nanosec', None)
+    if sec is None or nsec is None:
+        # In rospy, the time class has different attribute names.
+        sec = getattr(timestamp, 'secs', None)
+        nsec = getattr(timestamp, 'nsecs', None)
+
+    return sec * int(1e9) + nsec
 
 class MsgProcessor:
 
@@ -185,7 +194,7 @@ class MsgProcessor:
         raise NotImplementedError()
     
     def destroy(self):
-        pass
+        pass 
     
 class Msg2CSVProcessor(MsgProcessor):
     header : List[str] = []
@@ -219,8 +228,7 @@ class ImageProcessor(MsgProcessor):
     def process_message(self, msg, t):
         pass
 
-    @staticmethod
-    def _filename_nsec(msg):
+    def _filename_nsec(self, msg):
         """ Returns a filename from the timestamp in nanoseconds """
         return f'{to_nsec(msg.header.stamp)}.png'
     
@@ -233,25 +241,36 @@ class ImageProcessor(MsgProcessor):
         """ Returns a filename from an internally increasing count """
         return f'{self.count}.png'
 
-if cv_bridge:
-    class ImageProcessorCVBridge(ImageProcessor):
-        def process_message(self, msg, t):
-            cv_img = cv_bridge.imgmsg_to_cv2(msg)
-            if len(cv_img.shape) == 3:
-                cv_img = cv2.cvtColor(cv_img, cv2.COLOR_RGB2BGR)
-            filename = self.save_path / self._filename_nsec(msg)
-            cv2.imwrite(str(filename), cv_img)
-            self.count += 1
-else:
-    class ImageProcessorRosbags(ImageProcessor):
-        @override
-        def process_message(self, msg, t):
-            cv_img = message_to_cvimage(msg)
-            if len(cv_img.shape) == 3:
-                cv_img = cv2.cvtColor(cv_img, cv2.COLOR_RGB2BGR)
-            filename = self.save_path / self._filename_nsec(msg)
-            cv2.imwrite(str(filename), cv_img)
-            self.count += 1
+def get_image_processor(path: Path):
+    try:
+        from cv_bridge import CvBridge
+
+        class ImageProcessorCVBridge(ImageProcessor):
+            cv_bridge = CvBridge()
+
+            def process_message(self, msg, t):
+                cv_img = self.cv_bridge.imgmsg_to_cv2(msg)
+                if len(cv_img.shape) == 3:
+                    cv_img = cv2.cvtColor(cv_img, cv2.COLOR_RGB2BGR)
+                filename = self.save_path / self._filename_nsec(msg)
+                cv2.imwrite(str(filename), cv_img)
+                self.count += 1
+
+        return ImageProcessorCVBridge(path)
+
+    except ImportError:
+        from rosbags.image import message_to_cvimage
+
+        class ImageProcessorRosbags(ImageProcessor):
+            def process_message(self, msg, t):
+                cv_img = message_to_cvimage(msg)
+                if len(cv_img.shape) == 3:
+                    cv_img = cv2.cvtColor(cv_img, cv2.COLOR_RGB2BGR)
+                filename = self.save_path / self._filename_nsec(msg)
+                cv2.imwrite(str(filename), cv_img)
+                self.count += 1
+
+        return ImageProcessorRosbags(path)
 
 class NavSatFixProcessor(Msg2CSVProcessor):
     save_path: Path = Path("navsatfix.csv")
@@ -388,13 +407,6 @@ class PoseWithCovarianceStampedProcessor(Msg2CSVProcessor):
         ]
         self.writer.writerow(row)
 
-def to_nsec(stamp):
-    # if inside a ROS1 environment
-    if cv_bridge:
-        return stamp.to_nsec()
-    else:
-        return stamp.sec * int(1e9) + stamp.nanosec
-
 def check_timestamps(
         bag_file: Bag,
         args: argparse.Namespace,
@@ -526,6 +538,12 @@ if __name__ == '__main__':
     TOPIC_TO_PROCESSOR: Dict[str, MsgProcessor] = {
         '/realsense/imu': IMUProcessor(
             path=output_folder/'realsense'/'imu.csv'),
+        '/realsense/color/image_raw': get_image_processor(
+            path=output_folder/'realsense'/'color'),
+        '/realsense/infra1/image_rect_raw': get_image_processor(
+            path=output_folder/'realsense'/'infra1'),
+        '/realsense/infra2/image_rect_raw': get_image_processor(
+            path=output_folder/'realsense'/'infra2'),
         '/reach_1/fix': NavSatFixProcessor(
             path=output_folder/'reach1'/'fix.csv'),
         '/reach_1/imu': IMUProcessor(
@@ -589,33 +607,14 @@ if __name__ == '__main__':
         ),
     }
 
-    if cv_bridge:
-        TOPIC_TO_PROCESSOR['/realsense/color/image_raw'] = ImageProcessorCVBridge(
-            path=output_folder/'realsense'/'color')
-        TOPIC_TO_PROCESSOR['/realsense/infra1/image_rect_raw'] = ImageProcessorCVBridge(
-            path=output_folder/'realsense'/'infra1')
-        TOPIC_TO_PROCESSOR['/realsense/infra2/image_rect_raw'] = ImageProcessorCVBridge(
-            path=output_folder/'realsense'/'infra2')
-    else:
-        TOPIC_TO_PROCESSOR['/realsense/color/image_raw'] = ImageProcessorRosbags(
-            path=output_folder/'realsense'/'color')
-        TOPIC_TO_PROCESSOR['/realsense/infra1/image_rect_raw'] = ImageProcessorRosbags(
-            path=output_folder/'realsense'/'infra1')
-        TOPIC_TO_PROCESSOR['/realsense/infra2/image_rect_raw'] = ImageProcessorRosbags(
-            path=output_folder/'realsense'/'infra2')
-
-        
 
     # check input path and open rosbag file
     print(f'Opening rosbag located at {args.bag_path}...')
     assert(args.bag_path.is_file()), \
         f"Path to rosbag {args.bag_path} is not a valid path."
 
-    if 'rosbag' in sys.modules:
-        bag_file = BagROS1(args.bag_path)
-    else:
-        bag_file = BagRosbags(args.bag_path)
-    
+    bag_file = get_bag_handler(args.bag_path)
+
     # filter topics with provided options
     bag_topics = [topic for topic in bag_file.get_topics()]
     topics_not_found = list(set(args.topics) - set(bag_topics))

--- a/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
+++ b/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
@@ -37,14 +37,14 @@ import csv
 import cv2
 import os
 from pathlib import Path
-from typing import List, Dict, override
+from typing import List, Dict
 import sys
 
 try:
     import rosbag
     from cv_bridge import CvBridge
     cv_bridge = CvBridge()
-    import rospy.rostime.Time
+    from rospy import Time
 except ModuleNotFoundError:
     rosbag = None
     cv_bridge = None
@@ -54,6 +54,8 @@ except ModuleNotFoundError:
     from rosbags.typesys import Stores, get_typestore
 
     typestore = get_typestore(Stores.ROS1_NOETIC)
+
+    from typing import override
 
 SCRIPT_DESCRIPTION = \
     "This script allows the extraction of the rosbag data format to plain" \
@@ -119,24 +121,20 @@ if rosbag:
         def __init__(self, path: Path):
             self.bag = rosbag.Bag(path)
 
-        @override
         def get_start_time(self):
             return self.floatsec_to_intnsec(self.bag.get_start_time())
 
-        @override
         def get_end_time(self):
             return self.floatsec_to_intnsec(self.bag.get_end_time())
 
-        @override
         def read_messages(self, topics, start, stop):
             for topic, msg, t in self.bag.read_messages(
                         topics,
                         start_time=Time(self.intnsec_to_floatsec(start)),
                         end_time=Time(self.intnsec_to_floatsec(stop))
                     ):
-                yield (topic, msg, self.floatsec_to_intnsec(t))
+                yield (topic, msg, t.secs * int(1e9) + t.nsecs)
 
-        @override
         def get_topics(self):
             return self.bag.get_type_and_topic_info().topics
 
@@ -237,13 +235,12 @@ class ImageProcessor(MsgProcessor):
 
 if cv_bridge:
     class ImageProcessorCVBridge(ImageProcessor):
-        @override
         def process_message(self, msg, t):
             cv_img = cv_bridge.imgmsg_to_cv2(msg)
             if len(cv_img.shape) == 3:
                 cv_img = cv2.cvtColor(cv_img, cv2.COLOR_RGB2BGR)
             filename = self.save_path / self._filename_nsec(msg)
-            cv2.imwrite(filename, cv_img)
+            cv2.imwrite(str(filename), cv_img)
             self.count += 1
 else:
     class ImageProcessorRosbags(ImageProcessor):
@@ -253,7 +250,7 @@ else:
             if len(cv_img.shape) == 3:
                 cv_img = cv2.cvtColor(cv_img, cv2.COLOR_RGB2BGR)
             filename = self.save_path / self._filename_nsec(msg)
-            cv2.imwrite(filename, cv_img)
+            cv2.imwrite(str(filename), cv_img)
             self.count += 1
 
 class NavSatFixProcessor(Msg2CSVProcessor):
@@ -401,8 +398,8 @@ def to_nsec(stamp):
 def check_timestamps(
         bag_file: Bag,
         args: argparse.Namespace,
-) -> dict[str, int]:
-    params: dict[str, int] = {}
+) -> Dict[str, int]:
+    params: Dict[str, int] = {}
 
     start_nsec = bag_file.get_start_time()
     params['bag_start'] = start_nsec
@@ -412,8 +409,8 @@ def check_timestamps(
     def check_timestamp_validity(
             time: int,
             name: str,
-            params: dict[str, int]
-    ) -> dict[str, int]:
+            params: Dict[str, int]
+    ) -> Dict[str, int]:
         params[name] = time
         if time < start_nsec:
             print(f"Provided {name} time {time} is lower than rosbag start time {start_nsec}")
@@ -459,8 +456,8 @@ def check_timestamps(
 
 def extract_rosbag_data(
         bag_file: Bag,
-        processors: dict[str, MsgProcessor],
-        params: dict[str, int]):
+        processors: Dict[str, MsgProcessor],
+        params: Dict[str, int]):
     start_time = params['start_time']
     end_time = params['end_time']
 
@@ -526,7 +523,7 @@ if __name__ == '__main__':
 
     output_folder = args.output_folder
 
-    TOPIC_TO_PROCESSOR: dict[str, MsgProcessor] = {
+    TOPIC_TO_PROCESSOR: Dict[str, MsgProcessor] = {
         '/realsense/imu': IMUProcessor(
             path=output_folder/'realsense'/'imu.csv'),
         '/reach_1/fix': NavSatFixProcessor(

--- a/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
+++ b/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
@@ -604,8 +604,6 @@ if __name__ == '__main__':
         bag_file = BagROS1(args.bag_path)
     else:
         bag_file = BagRosbags(args.bag_path)
-        print(f"bag start {bag_file.get_start_time()} and end {bag_file.get_end_time()}")
-        print(f"bag duration {bag_file.bag.duration}")
     
     # filter topics with provided options
     bag_topics = [topic for topic in bag_file.get_topics()]

--- a/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
+++ b/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
@@ -286,10 +286,81 @@ class PoseWithCovarianceStampedProcessor(Msg2CSVProcessor):
         ]
         self.writer.writerow(row)
 
+def check_timestamps(
+        bag_file: rosbag.Bag,
+        args: argparse.Namespace,
+) -> dict[str, int]:
+    def floatsec_to_intnsec(float_sec):
+        int_sec = int(float_sec)
+        rem_sec = float_sec - int_sec
+        rem_nsec = int(rem_sec * int(1e9))
+        return (int_sec * int(1e9)) + rem_nsec
 
-def extraxct_rosbag_data(
-        bag_file: rosbag.Bag, processors: Dict[str, MsgProcessor]):
+    params: dict[str, int] = {}
+
+    start_nsec = floatsec_to_intnsec(bag_file.get_start_time())
+    params['bag_start'] = start_nsec
+    end_nsec = floatsec_to_intnsec(bag_file.get_end_time())
+    params['bag_end'] = end_nsec
+
+    def check_timestamp_validity(
+            time: int | None,
+            name: str,
+            params: dict[str, int]
+    ) -> dict[str, int]:
+        if time is not None:
+            params[name] = time
+            if time < start_nsec:
+                print(f"Provided {name} time is lower than rosbag start time")
+                exit(1)
+            if time > end_nsec:
+                print(f"Provided {name} time is higher than rosbag end time")
+                exit(1) 
+
+        return params
+
+    params = check_timestamp_validity(args.start, 'start', params)
+    params = check_timestamp_validity(args.end, 'end', params)
+
+    if args.start is not None and args.end is not None:
+        if args.start > args.end:
+            print(f"Provided start time is higher than end time")
+            exit(1)
+
+    # transform offset to unix epoch to compare with bag times
+    params = check_timestamp_validity(args.start_offset + start_nsec, 'start_offset', params)
+    params = check_timestamp_validity(args.end_offset + start_nsec, 'end_offset', params)
+
+    if params['start_offset'] is not None and params['end_offset'] is not None:
+        if params['start_offset'] > params['end_offset']:
+            print(f"Provided start time is higher than end time")
+            exit(1)
+
+    return params
+
+def extract_rosbag_data(
+        bag_file: rosbag.Bag,
+        processors: dict[str, MsgProcessor],
+        params: dict[str, int]):
+    start_time = params['bag_start']
+    if params['start'] is not None:
+        start_time = params['start']
+    elif params['start_offset'] is not None:
+        # offset has been made into unix epoch
+        start_time = params['start_offset']
+
+    end_time = params['bag_end']
+    if params['end'] is not None:
+        end_time = params['end']
+    elif params['end_offset'] is not None:
+        # offset has been made into unix epoch
+        end_time = params['end_offset']
+
     for topic, msg, t in bag_file.read_messages(topics=processors.keys()):
+        if t < start_time:
+            continue
+        if t > end_time:
+            break
         if topic not in processors.keys():
             continue
         try:
@@ -319,11 +390,21 @@ if __name__ == '__main__':
     )
     parser.add_argument(
         '--start', type=int, required=False,
-        help='Time (nsec) from which to start the processing the bag messages.'
+        help='Time (unix epoch time) from which to start processing the bag messages.'
     )
     parser.add_argument(
         '--end', type=int, required=False,
-        help='Time (nsec) up to which to process the bag messages.'
+        help='Time (unix epoch time) up to which to process the bag messages.'
+    )
+    parser.add_argument(
+        '--start_offset', type=int, required=False,
+        help='Time (nsec) from which to start processing the bag messages. ' \
+                'If both --start and --start_offset are set, prefer --start'
+    )
+    parser.add_argument(
+        '--end_offset', type=int, required=False,
+        help='Time (nsec) up to which to process the bag messages. ' \
+                'If both --end and --end_offset are set, prefer --end'
     )
     parser.add_argument(
         '-o', '--output-folder', type=Path, default='.',
@@ -333,9 +414,13 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    # check output folder
-    assert(args.output_folder.is_dir()), \
-        f"Path to output {args.output_folder} is not a valid folder."
+    if not args.output_folder.exists():
+        args.output_folder.mkdir()
+    else:
+        # check output folder
+        assert(args.output_folder.is_dir()), \
+            f"Path to output {args.output_folder} is not a valid folder."
+
     output_folder = args.output_folder
 
     TOPIC_TO_PROCESSOR = {
@@ -434,23 +519,11 @@ if __name__ == '__main__':
          if topic in TOPIC_TO_PROCESSOR.keys()}
 
     # check option timestamps
-    def floatsec_to_intnsec(float_sec):
-        int_sec = int(float_sec)
-        rem_sec = float_sec - int_sec
-        rem_nsec = int(rem_sec * int(1e9))
-        return (int_sec * int(1e9)) + rem_nsec
-    start_nsec = floatsec_to_intnsec(bag_file.get_start_time())
-    end_nsec = floatsec_to_intnsec(bag_file.get_end_time())
-    if args.start is not None and args.start < start_nsec:
-        print(f"Provided start time is lower than rosbag start time")
-        exit(1)
-    if args.end is not None and args.end < end_nsec:
-        print(f"Provided start time is higher than rosbag end time")
-        exit(1)
+    params = check_timestamps(bag_file, args)
 
     # execute data extraction
     print(f'Starting data extraction for {args.bag_path}')
 
-    extraxct_rosbag_data(bag_file, processors=filtered_topic_to_processor)
+    extract_rosbag_data(bag_file, processors=filtered_topic_to_processor, params=params)
 
     print(f'Finished extracting data for {args.bag_path}')

--- a/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
+++ b/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
@@ -40,7 +40,6 @@ from pathlib import Path
 from typing import List, Dict
 import sys
 from abc import ABC, abstractmethod
-from tqdm import tqdm
 
 
 SCRIPT_DESCRIPTION = \
@@ -104,77 +103,81 @@ class Bag(ABC):
     def get_topics(self):
         raise NotImplementedError()
 
+class NativeBag(Bag):
+    def __init__(self, path: Path):
+        super().__init__(path)
 
-def get_bag_handler(path: Path):
-    try:
-        import rosbag
+        from rosbag import Bag
+        self.bag = Bag(path)
+
+    def get_start_time(self):
+        return self.floatsec_to_intnsec(self.bag.get_start_time())
+
+    def get_end_time(self):
+        return self.floatsec_to_intnsec(self.bag.get_end_time())
+
+    def read_messages(self, topics, start, stop):
         from rospy import Time
+        for topic, msg, t in self.bag.read_messages(
+                    topics,
+                    start_time=Time(self.intnsec_to_floatsec(start)),
+                    end_time=Time(self.intnsec_to_floatsec(stop))
+                ):
+            yield (topic, msg, t.to_nsec())
 
-        class NativeBag(Bag):
-            bag: rosbag.Bag
+    def get_topics(self):
+        return self.bag.get_type_and_topic_info().topics
 
-            def __init__(self, path: Path):
-                super().__init__(path)
-                self.bag = rosbag.Bag(path)
+    @staticmethod
+    def floatsec_to_intnsec(float_sec):
+        int_sec = int(float_sec)
+        rem_sec = float_sec - int_sec
+        rem_nsec = int(rem_sec * int(1e9))
+        return (int_sec * int(1e9)) + rem_nsec
 
-            def get_start_time(self):
-                return self.floatsec_to_intnsec(self.bag.get_start_time())
+    @staticmethod
+    def intnsec_to_floatsec(intnsec):
+        return (float(intnsec) / 1e9)
 
-            def get_end_time(self):
-                return self.floatsec_to_intnsec(self.bag.get_end_time())
+class RosbagsBag(Bag):
+    def __init__(self, path: Path):
+        super().__init__(path)
 
-            def read_messages(self, topics, start, stop):
-                for topic, msg, t in self.bag.read_messages(
-                            topics,
-                            start_time=Time(self.intnsec_to_floatsec(start)),
-                            end_time=Time(self.intnsec_to_floatsec(stop))
-                        ):
-                    yield (topic, msg, t.to_nsec())
-
-            def get_topics(self):
-                return self.bag.get_type_and_topic_info().topics
-
-            @staticmethod
-            def floatsec_to_intnsec(float_sec):
-                int_sec = int(float_sec)
-                rem_sec = float_sec - int_sec
-                rem_nsec = int(rem_sec * int(1e9))
-                return (int_sec * int(1e9)) + rem_nsec
-
-            @staticmethod
-            def intnsec_to_floatsec(intnsec):
-                return (float(intnsec) / 1e9)
-
-        return NativeBag(path)
-    except ImportError:
         from rosbags.rosbag1 import Reader
         from rosbags.typesys import Stores, get_typestore
 
-        typestore = get_typestore(Stores.ROS1_NOETIC)
+        self.typestore = get_typestore(Stores.ROS1_NOETIC)
 
-        class RosbagsBag(Bag):
-            bag: Reader
+        self.bag = Reader(path)
+        self.bag.open()
 
-            def __init__(self, path: Path):
-                self.bag = Reader(path)
-                self.bag.open()
+    def get_start_time(self):
+        return self.bag.start_time
 
-            def get_start_time(self):
-                return self.bag.start_time
+    def get_end_time(self):
+        return self.bag.end_time
 
-            def get_end_time(self):
-                return self.bag.end_time
+    def read_messages(self, topics, start, stop):
+        connections = [x for x in self.bag.connections if x.topic in topics]
+        for connection, timestamp, rawdata in self.bag.messages(connections=connections, start=start, stop=stop):
+            msg = self.typestore.deserialize_ros1(rawdata, connection.msgtype)
+            yield connection.topic, msg, timestamp
 
-            def read_messages(self, topics, start, stop):
-                connections = [x for x in self.bag.connections if x.topic in topics]
-                for connection, timestamp, rawdata in self.bag.messages(connections=connections, start=start, stop=stop):
-                    msg = typestore.deserialize_ros1(rawdata, connection.msgtype)
-                    yield connection.topic, msg, timestamp
+    def get_topics(self):
+        return self.bag.topics
 
-            def get_topics(self):
-                return self.bag.topics
+def get_bag_handler(path: Path):
+    try:
+        return NativeBag(path)
+    except ImportError:
+        pass
 
+    try:
         return RosbagsBag(path)
+    except ImportError:
+        pass
+
+    raise ImportError("No libraries found to open rosbags")
 
 def to_nsec(timestamp):
     sec = getattr(timestamp, 'sec', None)
@@ -242,36 +245,50 @@ class ImageProcessor(MsgProcessor):
         """ Returns a filename from an internally increasing count """
         return f'{self.count}.png'
 
+class ImageProcessorCVBridge(ImageProcessor):
+    def __init__(self, path = None):
+        super().__init__(path)
+
+        from cv_bridge import CvBridge
+        cv_bridge = CvBridge()
+
+        self.cv_bridge = CvBridge()
+
+    def process_message(self, msg, t):
+        cv_img = self.cv_bridge.imgmsg_to_cv2(msg)
+        if len(cv_img.shape) == 3:
+            cv_img = cv2.cvtColor(cv_img, cv2.COLOR_RGB2BGR)
+        filename = self.save_path / self._filename_nsec(msg)
+        cv2.imwrite(str(filename), cv_img)
+        self.count += 1
+
+class ImageProcessorRosbags(ImageProcessor):
+    def __init__(self, path = None):
+        super().__init__(path)
+
+        from rosbags.image import message_to_cvimage
+        self.msg2cvimg = message_to_cvimage
+
+    def process_message(self, msg, t):
+        cv_img = self.msg2cvimg(msg)
+        if len(cv_img.shape) == 3:
+            cv_img = cv2.cvtColor(cv_img, cv2.COLOR_RGB2BGR)
+        filename = self.save_path / self._filename_nsec(msg)
+        cv2.imwrite(str(filename), cv_img)
+        self.count += 1
+
 def get_image_processor(path: Path):
     try:
-        from cv_bridge import CvBridge
-
-        class ImageProcessorCVBridge(ImageProcessor):
-            cv_bridge = CvBridge()
-
-            def process_message(self, msg, t):
-                cv_img = self.cv_bridge.imgmsg_to_cv2(msg)
-                if len(cv_img.shape) == 3:
-                    cv_img = cv2.cvtColor(cv_img, cv2.COLOR_RGB2BGR)
-                filename = self.save_path / self._filename_nsec(msg)
-                cv2.imwrite(str(filename), cv_img)
-                self.count += 1
-
         return ImageProcessorCVBridge(path)
-
     except ImportError:
-        from rosbags.image import message_to_cvimage
+        pass
 
-        class ImageProcessorRosbags(ImageProcessor):
-            def process_message(self, msg, t):
-                cv_img = message_to_cvimage(msg)
-                if len(cv_img.shape) == 3:
-                    cv_img = cv2.cvtColor(cv_img, cv2.COLOR_RGB2BGR)
-                filename = self.save_path / self._filename_nsec(msg)
-                cv2.imwrite(str(filename), cv_img)
-                self.count += 1
-
+    try:
         return ImageProcessorRosbags(path)
+    except ImportError:
+        pass
+
+    raise ImportError("No libraries found to process images")
 
 class NavSatFixProcessor(Msg2CSVProcessor):
     save_path: Path = Path("navsatfix.csv")
@@ -474,6 +491,26 @@ def extract_rosbag_data(
     start_time = params['start_time']
     end_time = params['end_time']
 
+    for topic, msg, t in bag_file.read_messages(topics=processors.keys(), start=start_time, stop=end_time):
+        if topic not in processors.keys():
+            continue
+        try:
+            processors[topic].process_message(msg, t)
+        except Exception as e:
+            print(e)
+            continue
+    for _,proc in processors.items():
+        proc.destroy()
+
+def extract_rosbag_data_with_progress(
+        bag_file: Bag,
+        processors: Dict[str, MsgProcessor],
+        params: Dict[str, int]):
+    from tqdm import tqdm
+
+    start_time = params['start_time']
+    end_time = params['end_time']
+
     length = end_time - start_time
     last_time = start_time
     with tqdm(total=length) as bar:
@@ -644,6 +681,9 @@ if __name__ == '__main__':
     # execute data extraction
     print(f'Starting data extraction for {args.bag_path}')
 
-    extract_rosbag_data(bag_file, processors=filtered_topic_to_processor, params=params)
+    try:
+        extract_rosbag_data_with_progress(bag_file, processors=filtered_topic_to_processor, params=params)
+    except ImportError:
+        extract_rosbag_data(bag_file, processors=filtered_topic_to_processor, params=params)
 
     print(f'Finished extracting data for {args.bag_path}')

--- a/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
+++ b/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from typing import List, Dict
 import sys
 from abc import ABC, abstractmethod
+from tqdm import tqdm
 
 
 SCRIPT_DESCRIPTION = \
@@ -473,16 +474,21 @@ def extract_rosbag_data(
     start_time = params['start_time']
     end_time = params['end_time']
 
-    for topic, msg, t in bag_file.read_messages(topics=processors.keys(), start=start_time, stop=end_time):
-        if topic not in processors.keys():
-            continue
-        try:
-            processors[topic].process_message(msg, t)
-        except Exception as e:
-            print(e)
-            continue
-    for _,proc in processors.items():
-        proc.destroy()
+    length = end_time - start_time
+    last_time = start_time
+    with tqdm(total=length) as bar:
+        for topic, msg, t in bag_file.read_messages(topics=processors.keys(), start=start_time, stop=end_time):
+            bar.update(t - last_time)
+            last_time = t
+            if topic not in processors.keys():
+                continue
+            try:
+                processors[topic].process_message(msg, t)
+            except Exception as e:
+                print(e)
+                continue
+        for _,proc in processors.items():
+            proc.destroy()
 
 if __name__ == '__main__':
 

--- a/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
+++ b/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
@@ -36,11 +36,23 @@ import argparse
 import csv
 import cv2
 import os
-import rosbag
-from cv_bridge import CvBridge
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, override
+import sys
 
+try:
+    import rosbag
+    from cv_bridge import CvBridge
+    cv_bridge = CvBridge()
+except ModuleNotFoundError:
+    rosbag = None
+    cv_bridge = None
+
+    from rosbags.rosbag1 import Reader
+    from rosbags.image import message_to_cvimage
+    from rosbags.typesys import Stores, get_typestore
+
+    typestore = get_typestore(Stores.ROS1_NOETIC)
 
 SCRIPT_DESCRIPTION = \
     "This script allows the extraction of the rosbag data format to plain" \
@@ -83,8 +95,70 @@ OUTPUT_STRUCTURE = \
     │   └── 2023-12-26-15-48-38/
     """
 
+class Bag:
+    def __init__(self, path: Path):
+        super().__init__()
 
-cv_bridge = CvBridge()
+    def get_start_time(self):
+        raise NotImplementedError()
+
+    def get_end_time(self):
+        raise NotImplementedError()
+
+    def read_messages(self, topics):
+        raise NotImplementedError()
+
+    def get_topics(self):
+        raise NotImplementedError()
+
+if rosbag:
+    class BagROS1(Bag):
+        bag: rosbag.Bag
+
+        def __init__(self, path: Path):
+            self.bag = rosbag.Bag(path)
+
+        @override
+        def get_start_time(self):
+            return self.bag.get_start_time()
+
+        @override
+        def get_end_time(self):
+            return self.bag.get_end_time()
+
+        @override
+        def read_messages(self, topics):
+            return self.bag.read_messages(topics)
+
+        @override
+        def get_topics(self):
+            return self.bag.get_type_and_topic_info().topics
+else:
+    class BagRosbags(Bag):
+        bag: Reader
+
+        def __init__(self, path: Path):
+            self.bag = Reader(path)
+            self.bag.open()
+
+        @override
+        def get_start_time(self):
+            return self.bag.start_time
+
+        @override
+        def get_end_time(self):
+            return self.bag.end_time
+
+        @override
+        def read_messages(self, topics):
+            connections = [x for x in self.bag.connections if x.topic in topics]
+            for connection, timestamp, rawdata in self.bag.messages(connections=connections):
+                msg = typestore.deserialize_ros1(rawdata, connection.msgtype)
+                yield connection.topic, msg, timestamp
+
+        @override
+        def get_topics(self):
+            return self.bag.topics
 
 
 class MsgProcessor:
@@ -98,7 +172,6 @@ class MsgProcessor:
     def destroy(self):
         pass
     
-
 class Msg2CSVProcessor(MsgProcessor):
     header : List[str] = []
 
@@ -120,7 +193,7 @@ class Msg2CSVProcessor(MsgProcessor):
     
 
 class ImageProcessor(MsgProcessor):
-    save_path: str = "images/"
+    save_path: Path = Path("images/")
     count: int = 0
 
     def __init__(self, path = None):
@@ -129,12 +202,7 @@ class ImageProcessor(MsgProcessor):
         os.makedirs(self.save_path, exist_ok=True)
 
     def process_message(self, msg, t):
-        cv_img = cv_bridge.imgmsg_to_cv2(msg)
-        if len(cv_img.shape) == 3:
-            cv_img = cv2.cvtColor(cv_img, cv2.COLOR_RGB2BGR)
-        filename = self.save_path / self._filename_nsec(msg)
-        cv2.imwrite(filename, cv_img)
-        self.count += 1
+        pass
 
     @staticmethod
     def _filename_nsec(msg):
@@ -150,9 +218,29 @@ class ImageProcessor(MsgProcessor):
         """ Returns a filename from an internally increasing count """
         return f'{self.count}.png'
 
+if cv_bridge:
+    class ImageProcessorCVBridge(ImageProcessor):
+        @override
+        def process_message(self, msg, t):
+            cv_img = cv_bridge.imgmsg_to_cv2(msg)
+            if len(cv_img.shape) == 3:
+                cv_img = cv2.cvtColor(cv_img, cv2.COLOR_RGB2BGR)
+            filename = self.save_path / self._filename_nsec(msg)
+            cv2.imwrite(filename, cv_img)
+            self.count += 1
+else:
+    class ImageProcessorRosbags(ImageProcessor):
+        @override
+        def process_message(self, msg, t):
+            cv_img = message_to_cvimage(msg)
+            if len(cv_img.shape) == 3:
+                cv_img = cv2.cvtColor(cv_img, cv2.COLOR_RGB2BGR)
+            filename = self.save_path / self._filename_nsec(msg)
+            cv2.imwrite(filename, cv_img)
+            self.count += 1
 
 class NavSatFixProcessor(Msg2CSVProcessor):
-    save_path: str = "navsatfix.csv"
+    save_path: Path = Path("navsatfix.csv")
     header: List[str] = [
         "nsec", "status", "service",
         "latitude", "longitude", "altitude",]
@@ -167,7 +255,7 @@ class NavSatFixProcessor(Msg2CSVProcessor):
 
 
 class IMUProcessor(Msg2CSVProcessor):
-    save_path: str = "imu.csv"
+    save_path: Path = Path("imu.csv")
     header: List[str] = [
         "nsec",
         "orientation", "orientation_covariance",
@@ -205,14 +293,14 @@ class IMUProcessor(Msg2CSVProcessor):
 
 
 class OdometryProcessor(Msg2CSVProcessor):
-    save_path: str = "odometry.csv"
+    save_path: Path = Path("odometry.csv")
 
     def process_message(self, msg, t):
         pass
 
 
 class MagneticFieldProcessor(Msg2CSVProcessor):
-    save_path: str = "magnetic_field.csv"
+    save_path: Path = Path("magnetic_field.csv")
     header: List[str] = [
         "nsec",
         "magnetic_field", "magnetic_field_covariance"]
@@ -233,7 +321,7 @@ class MagneticFieldProcessor(Msg2CSVProcessor):
 
 
 class TwistStampedProcessor(Msg2CSVProcessor):
-    save_path: str = "twist_stamped.csv"
+    save_path: Path = Path("twist_stamped.csv")
     header: List[str] = [
         "nsec",
         "linear", "angular"]
@@ -259,7 +347,7 @@ class TwistStampedProcessor(Msg2CSVProcessor):
 
 
 class PoseWithCovarianceStampedProcessor(Msg2CSVProcessor):
-    save_path: str = "posewcovar_stamped.csv"
+    save_path: Path = Path("posewcovar_stamped.csv")
     header: List[str] = [
         "nsec",
         "position", "orientation", "covariance"]
@@ -287,7 +375,7 @@ class PoseWithCovarianceStampedProcessor(Msg2CSVProcessor):
         self.writer.writerow(row)
 
 def check_timestamps(
-        bag_file: rosbag.Bag,
+        bag_file: Bag,
         args: argparse.Namespace,
 ) -> dict[str, int]:
     def floatsec_to_intnsec(float_sec):
@@ -304,57 +392,59 @@ def check_timestamps(
     params['bag_end'] = end_nsec
 
     def check_timestamp_validity(
-            time: int | None,
+            time: int,
             name: str,
             params: dict[str, int]
     ) -> dict[str, int]:
-        if time is not None:
-            params[name] = time
-            if time < start_nsec:
-                print(f"Provided {name} time is lower than rosbag start time")
-                exit(1)
-            if time > end_nsec:
-                print(f"Provided {name} time is higher than rosbag end time")
-                exit(1) 
-
-        return params
-
-    params = check_timestamp_validity(args.start, 'start', params)
-    params = check_timestamp_validity(args.end, 'end', params)
-
-    if args.start is not None and args.end is not None:
-        if args.start > args.end:
-            print(f"Provided start time is higher than end time")
+        params[name] = time
+        if time < start_nsec:
+            print(f"Provided {name} time {time} is lower than rosbag start time {start_nsec}")
             exit(1)
+        if time > end_nsec:
+            print(f"Provided {name} time {time} is higher than rosbag end time {end_nsec}")
+            exit(1) 
+
+        return params 
+
+    if args.start:
+        params = check_timestamp_validity(args.start, 'start', params)
+    if args.end:
+        params = check_timestamp_validity(args.end, 'end', params)
 
     # transform offset to unix epoch to compare with bag times
-    params = check_timestamp_validity(args.start_offset + start_nsec, 'start_offset', params)
-    params = check_timestamp_validity(args.end_offset + start_nsec, 'end_offset', params)
+    if args.start_offset:
+        params = check_timestamp_validity(args.start_offset + start_nsec, 'start_offset', params)
+    if args.end_offset:
+        params = check_timestamp_validity(args.end_offset + start_nsec, 'end_offset', params)
 
-    if params['start_offset'] is not None and params['end_offset'] is not None:
-        if params['start_offset'] > params['end_offset']:
-            print(f"Provided start time is higher than end time")
-            exit(1)
+    if params.get('start') is not None:
+        params['start_time'] = params['start']
+    elif params.get('start_offset') is not None:
+        # offset has been made into unix epoch
+        params['start_time'] = params['start_offset'] 
+    else:
+        params['start_time'] = params['bag_start']
+        
+    if params.get('end') is not None:
+        params['end_time'] = params['end']
+    elif params.get('end_offset') is not None:
+        # offset has been made into unix epoch
+        params['end_time'] = params['end_offset']
+    else:
+        params['end_time'] = params['bag_end']
+
+    if params['start_time'] > params['end_time']:
+        print(f"Provided start time is higher than end time")
+        exit(1)
 
     return params
 
 def extract_rosbag_data(
-        bag_file: rosbag.Bag,
+        bag_file: Bag,
         processors: dict[str, MsgProcessor],
         params: dict[str, int]):
-    start_time = params['bag_start']
-    if params['start'] is not None:
-        start_time = params['start']
-    elif params['start_offset'] is not None:
-        # offset has been made into unix epoch
-        start_time = params['start_offset']
-
-    end_time = params['bag_end']
-    if params['end'] is not None:
-        end_time = params['end']
-    elif params['end_offset'] is not None:
-        # offset has been made into unix epoch
-        end_time = params['end_offset']
+    start_time = params['start_time']
+    end_time = params['end_time']
 
     for topic, msg, t in bag_file.read_messages(topics=processors.keys()):
         if t < start_time:
@@ -370,7 +460,6 @@ def extract_rosbag_data(
             continue
     for _,proc in processors.items():
         proc.destroy()
-
 
 if __name__ == '__main__':
 
@@ -423,13 +512,7 @@ if __name__ == '__main__':
 
     output_folder = args.output_folder
 
-    TOPIC_TO_PROCESSOR = {
-        '/realsense/color/image_raw': ImageProcessor(
-            path=output_folder/'realsense'/'color'),
-        '/realsense/infra1/image_rect_raw': ImageProcessor(
-            path=output_folder/'realsense'/'infra1'),
-        '/realsense/infra2/image_rect_raw': ImageProcessor(
-            path=output_folder/'realsense'/'infra2'),
+    TOPIC_TO_PROCESSOR: dict[str, MsgProcessor] = {
         '/realsense/imu': IMUProcessor(
             path=output_folder/'realsense'/'imu.csv'),
         '/reach_1/fix': NavSatFixProcessor(
@@ -495,14 +578,37 @@ if __name__ == '__main__':
         ),
     }
 
+    if cv_bridge:
+        TOPIC_TO_PROCESSOR['/realsense/color/image_raw'] = ImageProcessorCVBridge(
+            path=output_folder/'realsense'/'color')
+        TOPIC_TO_PROCESSOR['/realsense/infra1/image_rect_raw'] = ImageProcessorCVBridge(
+            path=output_folder/'realsense'/'infra1')
+        TOPIC_TO_PROCESSOR['/realsense/infra2/image_rect_raw'] = ImageProcessorCVBridge(
+            path=output_folder/'realsense'/'infra2')
+    else:
+        TOPIC_TO_PROCESSOR['/realsense/color/image_raw'] = ImageProcessorRosbags(
+            path=output_folder/'realsense'/'color')
+        TOPIC_TO_PROCESSOR['/realsense/infra1/image_rect_raw'] = ImageProcessorRosbags(
+            path=output_folder/'realsense'/'infra1')
+        TOPIC_TO_PROCESSOR['/realsense/infra2/image_rect_raw'] = ImageProcessorRosbags(
+            path=output_folder/'realsense'/'infra2')
+
+        
+
     # check input path and open rosbag file
     print(f'Opening rosbag located at {args.bag_path}...')
     assert(args.bag_path.is_file()), \
         f"Path to rosbag {args.bag_path} is not a valid path."
-    bag_file = rosbag.Bag(args.bag_path)
+
+    if 'rosbag' in sys.modules:
+        bag_file = BagROS1(args.bag_path)
+    else:
+        bag_file = BagRosbags(args.bag_path)
+        print(f"bag start {bag_file.get_start_time()} and end {bag_file.get_end_time()}")
+        print(f"bag duration {bag_file.bag.duration}")
     
     # filter topics with provided options
-    bag_topics = [topic for topic in bag_file.get_type_and_topic_info().topics]
+    bag_topics = [topic for topic in bag_file.get_topics()]
     topics_not_found = list(set(args.topics) - set(bag_topics))
     skip_not_found = list(set(args.skip) - set(bag_topics))
     not_found = topics_not_found + skip_not_found

--- a/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
+++ b/ros1_ws/src/ros1_scripts/extract_rosbag_data.py
@@ -44,6 +44,7 @@ try:
     import rosbag
     from cv_bridge import CvBridge
     cv_bridge = CvBridge()
+    import rospy.rostime.Time
 except ModuleNotFoundError:
     rosbag = None
     cv_bridge = None
@@ -105,7 +106,7 @@ class Bag:
     def get_end_time(self):
         raise NotImplementedError()
 
-    def read_messages(self, topics):
+    def read_messages(self, topics, start, stop):
         raise NotImplementedError()
 
     def get_topics(self):
@@ -120,19 +121,35 @@ if rosbag:
 
         @override
         def get_start_time(self):
-            return self.bag.get_start_time()
+            return self.floatsec_to_intnsec(self.bag.get_start_time())
 
         @override
         def get_end_time(self):
-            return self.bag.get_end_time()
+            return self.floatsec_to_intnsec(self.bag.get_end_time())
 
         @override
-        def read_messages(self, topics):
-            return self.bag.read_messages(topics)
+        def read_messages(self, topics, start, stop):
+            for topic, msg, t in self.bag.read_messages(
+                        topics,
+                        start_time=Time(self.intnsec_to_floatsec(start)),
+                        end_time=Time(self.intnsec_to_floatsec(stop))
+                    ):
+                yield (topic, msg, self.floatsec_to_intnsec(t))
 
         @override
         def get_topics(self):
             return self.bag.get_type_and_topic_info().topics
+
+        @staticmethod
+        def floatsec_to_intnsec(float_sec):
+            int_sec = int(float_sec)
+            rem_sec = float_sec - int_sec
+            rem_nsec = int(rem_sec * int(1e9))
+            return (int_sec * int(1e9)) + rem_nsec
+
+        @staticmethod
+        def intnsec_to_floatsec(intnsec):
+            return (float(intnsec) / 1e9)
 else:
     class BagRosbags(Bag):
         bag: Reader
@@ -150,9 +167,9 @@ else:
             return self.bag.end_time
 
         @override
-        def read_messages(self, topics):
+        def read_messages(self, topics, start, stop):
             connections = [x for x in self.bag.connections if x.topic in topics]
-            for connection, timestamp, rawdata in self.bag.messages(connections=connections):
+            for connection, timestamp, rawdata in self.bag.messages(connections=connections, start=start, stop=stop):
                 msg = typestore.deserialize_ros1(rawdata, connection.msgtype)
                 yield connection.topic, msg, timestamp
 
@@ -207,7 +224,7 @@ class ImageProcessor(MsgProcessor):
     @staticmethod
     def _filename_nsec(msg):
         """ Returns a filename from the timestamp in nanoseconds """
-        return f'{msg.header.stamp.to_nsec()}.png'
+        return f'{to_nsec(msg.header.stamp)}.png'
     
     @staticmethod
     def _filename_seq(msg):
@@ -248,7 +265,7 @@ class NavSatFixProcessor(Msg2CSVProcessor):
 
     def process_message(self, msg, t):
         row = [
-            msg.header.stamp.to_nsec(), 
+            to_nsec(msg.header.stamp), 
             msg.status.status, msg.status.service
             ] + [getattr(msg, e) for e in self.header[3:]]
         self.writer.writerow(row)
@@ -281,7 +298,7 @@ class IMUProcessor(Msg2CSVProcessor):
         ]
 
         row = [
-            msg.header.stamp.to_nsec(),
+            to_nsec(msg.header.stamp),
             orientation,
             msg.orientation_covariance,
             angular_velocity,
@@ -313,7 +330,7 @@ class MagneticFieldProcessor(Msg2CSVProcessor):
         ]
 
         row = [
-            msg.header.stamp.to_nsec(), 
+            to_nsec(msg.header.stamp), 
             magnetic_field,
             msg.magnetic_field_covariance
         ]
@@ -339,7 +356,7 @@ class TwistStampedProcessor(Msg2CSVProcessor):
         ]
 
         row = [
-            msg.header.stamp.to_nsec(), 
+            to_nsec(msg.header.stamp), 
             linear,
             angular
         ]
@@ -367,28 +384,29 @@ class PoseWithCovarianceStampedProcessor(Msg2CSVProcessor):
         ]
 
         row = [
-            msg.header.stamp.to_nsec(),
+            to_nsec(msg.header.stamp),
             position,
             orientation,
             msg.pose.covariance,
         ]
         self.writer.writerow(row)
 
+def to_nsec(stamp):
+    # if inside a ROS1 environment
+    if cv_bridge:
+        return stamp.to_nsec()
+    else:
+        return stamp.sec * int(1e9) + stamp.nanosec
+
 def check_timestamps(
         bag_file: Bag,
         args: argparse.Namespace,
 ) -> dict[str, int]:
-    def floatsec_to_intnsec(float_sec):
-        int_sec = int(float_sec)
-        rem_sec = float_sec - int_sec
-        rem_nsec = int(rem_sec * int(1e9))
-        return (int_sec * int(1e9)) + rem_nsec
-
     params: dict[str, int] = {}
 
-    start_nsec = floatsec_to_intnsec(bag_file.get_start_time())
+    start_nsec = bag_file.get_start_time()
     params['bag_start'] = start_nsec
-    end_nsec = floatsec_to_intnsec(bag_file.get_end_time())
+    end_nsec = bag_file.get_end_time()
     params['bag_end'] = end_nsec
 
     def check_timestamp_validity(
@@ -446,11 +464,7 @@ def extract_rosbag_data(
     start_time = params['start_time']
     end_time = params['end_time']
 
-    for topic, msg, t in bag_file.read_messages(topics=processors.keys()):
-        if t < start_time:
-            continue
-        if t > end_time:
-            break
+    for topic, msg, t in bag_file.read_messages(topics=processors.keys(), start=start_time, stop=end_time):
         if topic not in processors.keys():
             continue
         try:

--- a/ros1_ws/src/ros1_scripts/requirements.txt
+++ b/ros1_ws/src/ros1_scripts/requirements.txt
@@ -5,3 +5,6 @@ opencv-python
 pyyaml
 rospkg
 tqdm
+
+rosbags
+rosbags-image


### PR DESCRIPTION
The idea of the script is to extract data into a format that doesn't depend on ROS1. If you already have a ROS1 installation, you can just play the rosbag and use the data from there. Now, you can extract the data without having a ROS1 installation by using rosbags.